### PR TITLE
Speed up line rendering when using step groups

### DIFF
--- a/pterm_stepgroup.go
+++ b/pterm_stepgroup.go
@@ -168,5 +168,5 @@ func spinner() pterm.SpinnerPrinter {
 }
 
 func (s *pTermStep) minimumLag() time.Duration {
-	return s.printer.Delay + time.Millisecond*150
+	return s.printer.Delay + time.Millisecond*5
 }


### PR DESCRIPTION
Resolves #5 

Minimised the delay required to compensate for spinner animation when rendering step groups.

This has demonstrably sped up rendering.